### PR TITLE
Allow getting bank names from IBAN

### DIFF
--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import string
+from functools import cached_property
 from typing import Dict
 from typing import Optional
 
@@ -226,9 +227,7 @@ class IBAN(common.Base):
             raise exceptions.InvalidChecksumDigits("Invalid checksum digits")
 
     def _validate_bban_checksum(self) -> None:
-        bank_registry = registry.get("bank_code")
-        assert isinstance(bank_registry, dict)
-        bank = bank_registry.get((self.country_code, self.bank_code), {})
+        bank = self.bank or {}
         algo_name = bank.get("checksum_algo", "default")
         algo = algorithms.get(f"{self.country_code}:{algo_name}")
         if algo is None:
@@ -328,6 +327,36 @@ class IBAN(common.Base):
     def account_code(self) -> str:
         """str: The customer specific account-code"""
         return self._get_code(code_type="account_code")
+
+    @cached_property
+    def bank(self) -> Optional[dict]:
+        bank_registry = registry.get("bank_code")
+        assert isinstance(bank_registry, dict)
+        return bank_registry.get((self.country_code, self.bank_code))
+
+    @property
+    def bank_name(self) -> Optional[str]:
+        """List[str]: The name of the bank associated with the IBAN bank code.
+
+        Examples:
+            >>> IBAN('DE89370400440532013000').bank_name
+            'Commerzbank'
+
+        """
+
+        return None if self.bank is None else self.bank["name"]
+
+    @property
+    def bank_short_name(self) -> Optional[str]:
+        """List[str]: The name of the bank associated with the IBAN bank code.
+
+        Examples:
+            >>> IBAN('DE89370400440532013000').bank_name
+            'Commerzbank Köln'
+
+        """
+
+        return None if self.bank is None else self.bank["short_name"]
 
 
 def add_bban_regex(country: str, spec: Dict) -> Dict:

--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -351,7 +351,7 @@ class IBAN(common.Base):
         """List[str]: The name of the bank associated with the IBAN bank code.
 
         Examples:
-            >>> IBAN('DE89370400440532013000').bank_name
+            >>> IBAN('DE89370400440532013000').bank_short_name
             'Commerzbank Köln'
 
         """

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -133,6 +133,8 @@ def test_iban_properties():
     assert iban.formatted == "DE42 4306 0967 7000 5341 00"
     assert iban.length == len(iban) == 22
     assert iban.country == countries.get(alpha_2="DE")
+    assert iban.bank_name == "GLS Gemeinschaftsbank"
+    assert iban.bank_short_name == "GLS Gemeinschaftsbk Bochum"
 
 
 @pytest.mark.parametrize(
@@ -211,3 +213,11 @@ def test_bic_from_iban(iban, bic):
 
 def test_unknown_bic_from_iban():
     assert IBAN("SI72000001234567892").bic is None
+
+
+def test_unknown_bank_name_from_iban():
+    assert IBAN("SI72000001234567892").bank_name is None
+
+
+def test_unknown_bank_name_short_from_iban():
+    assert IBAN("SI72000001234567892").bank_short_name is None


### PR DESCRIPTION
He dejado en schiwfty https://github.com/mdomke/schwifty/issues/82 a ver que opina el creador, mientras tanto, voy dejando PR por aqui para usar internamente.

He probado con el IBAN que nos dió problemas esta mañana:
```python
In [2]: IBAN("ES75008103103900XXXXXXXX").bank_name
Out[2]: 'BANCO DE SABADELL, S.A.'

In [3]: IBAN("ES75008103103900XXXXXXXX").bank_short_name
Out[3]: 'BANCO SABADELL'
```
